### PR TITLE
SpringBoot 3.0.8로 변경, Request/Result 클래스의 필드 final 키워드 제거

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.0.9'
+	id 'org.springframework.boot' version '3.0.8'
 	id 'io.spring.dependency-management' version '1.1.2'
 }
 

--- a/src/main/java/synopsis/graphql/model/dto/request/RequestScsData.java
+++ b/src/main/java/synopsis/graphql/model/dto/request/RequestScsData.java
@@ -20,6 +20,7 @@ public class RequestScsData implements GraphQLInputType {
     private List<RequestScsPpvProduct> ppvProducts;
 
     public RequestScsData() {}
+
     public RequestScsData(RequestData requestData) {
         this.stbId = requestData.getStbId();
         this.hashId = requestData.getHashId();

--- a/src/main/java/synopsis/graphql/model/dto/request/RequestScsPpvProduct.java
+++ b/src/main/java/synopsis/graphql/model/dto/request/RequestScsPpvProduct.java
@@ -7,19 +7,17 @@ import graphql.util.TraversalControl;
 import graphql.util.TraverserContext;
 import lombok.Builder;
 import lombok.Data;
-import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor
 @Builder
 @Data
 public class RequestScsPpvProduct implements GraphQLInputType {
 
-    private final String productPriceId;
-    private final String isNScreen;
-    private final String productTypeCode;
-    private final  String purchasePreferenceRank;
-    private final String isPossession;
-    private final String episodeId;
+    private String productPriceId;
+    private String isNScreen;
+    private String productTypeCode;
+    private  String purchasePreferenceRank;
+    private String isPossession;
+    private String episodeId;
 
     @Override
     public TraversalControl accept(TraverserContext<GraphQLSchemaElement> context, GraphQLTypeVisitor visitor) {

--- a/src/main/java/synopsis/graphql/model/exup/EuxpResult.java
+++ b/src/main/java/synopsis/graphql/model/exup/EuxpResult.java
@@ -8,25 +8,23 @@ import graphql.schema.SchemaElementChildrenContainer;
 import graphql.util.TraversalControl;
 import graphql.util.TraverserContext;
 import lombok.Data;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 import java.util.List;
 
+
 @Data
-@RequiredArgsConstructor
 public class EuxpResult implements GraphQLOutputType {
-    public final String result;
-    public final String reason;
-    public final String request_time;
-    public final Contents contents;
-    public final List<Purchare> purchares;
-    public final List<Object> series;
-    public final int total_banner_count;
-    public final String response_time;
+    private String result;
+    public String reason;
+    public String request_time;
+    public Contents contents;
+    public List<Purchare> purchares;
+    public List<Object> series;
+    public int total_banner_count;
+    public String response_time;
     @JsonProperty("IF")
-    public final String iF;
-    public final List<Object> banners;
+    public String iF;
+    public List<Object> banners;
 
     @Override
     public List<GraphQLSchemaElement> getChildren() {
@@ -36,11 +34,6 @@ public class EuxpResult implements GraphQLOutputType {
     @Override
     public SchemaElementChildrenContainer getChildrenWithTypeReferences() {
         return GraphQLOutputType.super.getChildrenWithTypeReferences();
-    }
-
-    @Override
-    public GraphQLSchemaElement withNewChildren(SchemaElementChildrenContainer newChildren) {
-        return GraphQLOutputType.super.withNewChildren(newChildren);
     }
 
     @Override

--- a/src/main/java/synopsis/graphql/model/scs/ScsResult.java
+++ b/src/main/java/synopsis/graphql/model/scs/ScsResult.java
@@ -2,28 +2,25 @@ package synopsis.graphql.model.scs;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 import java.util.List;
 
 @Data
-@RequiredArgsConstructor
 public class ScsResult {
     @JsonProperty("IF")
-    public final String iF;
-    public final String ver;
-    public final String ui_name;
-    public final String svc_name;
-    public final String result;
-    public final String reason;
-    public final String stb_id;
-    public final Object mobile_id;
-    public final String is_bookmark;
-    public final String yn_season_watch_all;
-    public final List<PpvProduct> ppv_products;
-    public final List<PpsProduct> pps_products;
-    public final Object last_watch_info;
+    public String iF;
+    public String ver;
+    public String ui_name;
+    public String svc_name;
+    public String result;
+    public String reason;
+    public String stb_id;
+    public Object mobile_id;
+    public String is_bookmark;
+    public String yn_season_watch_all;
+    public List<PpvProduct> ppv_products;
+    public List<PpsProduct> pps_products;
+    public Object last_watch_info;
 }
 
 

--- a/src/main/java/synopsis/graphql/model/smd/SmdResult.java
+++ b/src/main/java/synopsis/graphql/model/smd/SmdResult.java
@@ -8,22 +8,19 @@ import graphql.schema.GraphQLTypeVisitor;
 import graphql.util.TraversalControl;
 import graphql.util.TraverserContext;
 import lombok.Data;
-import lombok.RequiredArgsConstructor;
-
 
 @Data
-@RequiredArgsConstructor
 public class SmdResult implements GraphQLOutputType {
-    public final String result;
-    public final String reason;
-    public final String dislike_total;
-    public final String updateDate_total;
-    public final String like_total;
-    public final String dislike;
-    public final String like;
+    public String result;
+    public String reason;
+    public String dislike_total;
+    public String updateDate_total;
+    public String like_total;
+    public String dislike;
+    public String like;
     @JsonProperty("IF")
-    public final String iF;
-    public final String updateDate;
+    public String iF;
+    public String updateDate;
 
     @Override
     public TraversalControl accept(TraverserContext<GraphQLSchemaElement> context, GraphQLTypeVisitor visitor) {

--- a/src/main/java/synopsis/graphql/service/EuxpService.java
+++ b/src/main/java/synopsis/graphql/service/EuxpService.java
@@ -34,17 +34,14 @@ public class EuxpService {
         uriComponentsBuilder.queryParam("menu_stb_svc_id", requestEuxpData.getMenuStbServiceId());
         uriComponentsBuilder.queryParam("epsd_id", requestEuxpData.getEpisodeId());
         String url = uriComponentsBuilder.toUriString();
-        log.info("url = " + url);
-
-        String encodedUrl = url.replace("%25", "%");
-        log.info(encodedUrl);
 
         HttpEntity<Object> entity = new HttpEntity<>(headers);
-        ResponseEntity<String> response = restTemplate.exchange(encodedUrl,
+        ResponseEntity<String> response = restTemplate.exchange(
+                url,
                 HttpMethod.GET,
                 entity,
-                String.class);
-
+                String.class
+        );
 
         log.info(response.getBody());
 


### PR DESCRIPTION
## Spring Boot version
- v. `3.0.8`
- java `17` 
- build.gradle
```java
plugins {
	id 'java'
	id 'org.springframework.boot' version '3.0.8'
	id 'io.spring.dependency-management' version '1.1.2'
}
```

